### PR TITLE
Fix project and load script

### DIFF
--- a/src/eurostat/server.fsx
+++ b/src/eurostat/server.fsx
@@ -5,7 +5,7 @@
 #r "Newtonsoft.Json/lib/net40/Newtonsoft.Json.dll"
 #r "Suave/lib/net40/Suave.dll"
 #load "../serializer.fs"
-#load "eurostat-sci-domain.fs"
+#load "vocab.fs" "request.fs" "dictionary.fs" "data.fs" "tree.fs" "eurostat-sci-domain.fs"
 #else
 module Services.Eurostat
 #endif

--- a/src/services.fsproj
+++ b/src/services.fsproj
@@ -63,13 +63,14 @@
     <Compile Include="worldbank\domain.fs" />
     <Compile Include="worldbank\server.fsx" />
     <Compile Include="pivot\server.fsx" />
-    <Compile Include="release.fs" />
+    <Compile Include="eurostat\vocab.fs" />
     <Compile Include="eurostat\request.fs" />
     <Compile Include="eurostat\dictionary.fs" />
     <Compile Include="eurostat\data.fs" />
     <Compile Include="eurostat\tree.fs" />
     <Compile Include="eurostat\eurostat-sci-domain.fs" />
-    <Compile Include="eurostat\server.fs" />
+    <Compile Include="eurostat\server.fsx" />
+    <Compile Include="release.fs" />
     <None Include="debug.fsx" />
     <None Include="paket.references" />
   </ItemGroup>


### PR DESCRIPTION
The way the project is setup, all the files that are part of the script need to be listed in both the `server.fsx` file and also in the project file - the `#load` command in the script makes it possible to run everything in F# Interactive (which does not know anything about project files and only loads files that are explicitly specified) and the project file is useful so that editors (VS Code) know about all the files that are part of the project and can give the right auto-complete.

(This is a bit silly, ideally, we should just need this in one place - but sadly, that's the way things are at the moment.) 